### PR TITLE
Fix compilation with gcc-8.3 and ffmpg 4.1  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,9 @@ add_executable(TestDCT "${EXAMPLEDIR}/test_imagephash.cpp")
 target_link_libraries (TestDCT pHash)
 install(TARGETS TestDCT DESTINATION bin)
 
-add_executable(TestRadish "${EXAMPLEDIR}/test_radish.cpp")
-target_link_libraries (TestRadish pHash)
-install(TARGETS TestRadish DESTINATION bin)
+#add_executable(TestRadish "${EXAMPLEDIR}/test_radish.cpp")
+#target_link_libraries (TestRadish pHash)
+#install(TARGETS TestRadish DESTINATION bin)
 
 #add_executable(TestBMB "${EXAMPLEDIR}/test_bmbimagehash.cpp")
 #target_link_libraries (TestBMB pHash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ install(TARGETS pHash DESTINATION lib)
 
 set(EXAMPLEDIR examples)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 if(HAVE_IMAGE_HASH)
 add_executable(TestDCT "${EXAMPLEDIR}/test_imagephash.cpp")
 target_link_libraries (TestDCT pHash)

--- a/configure.ac
+++ b/configure.ac
@@ -122,15 +122,17 @@ fi])
 AC_DEFUN([AC_CHECK_FFMPEG],
 [
 AC_MSG_CHECKING([whether FFmpeg is present])
-AC_CHECK_LIB([avcodec], [avcodec_alloc_frame], [], [AC_MSG_ERROR([
-
-*** libavcodec not found.
-You need FFmpeg. Get it at <http://ffmpeg.org/>])])
 
 AC_CHECK_LIB([avutil], [av_log_set_level], [], [AC_MSG_ERROR([
 
 *** libavutil not found.
 You need FFmpeg. Get it at <http://ffmpeg.org/>])])
+
+AC_CHECK_LIB([avcodec], [av_frame_alloc], [], [AC_MSG_ERROR([
+
+*** libavcodec not found.
+You need FFmpeg. Get it at <http://ffmpeg.org/>])], [-lavutil])
+
 
 AC_CHECK_LIB([avformat], [av_read_frame], [], [AC_MSG_ERROR([
 

--- a/configure.ac
+++ b/configure.ac
@@ -261,7 +261,7 @@ AS_IF([test "x$enable_image_hash" != "xno" -o "x$enable_video_hash" != "xno"],
 
 AS_IF([test "x$with_fftw" != "xno"],
   AC_CHECK_LIB([fftw3], [fftw_plan_dft_r2c_1d],
-    [ CPPFLAGS="$CPPFLAGS -Dcimg_use_fftw3" LIBS="$LIBS -lfftw3" ],
+    [ CPPFLAGS="$CPPFLAGS -Dcimg_use_fftw3" LIBS="$LIBS -lfftw3_threads -lfftw3" ],
     AS_IF([test "x$with_fftw" = "xyes"], AC_MSG_ERROR([FFTW support requested but library not found]))
   )
 )

--- a/src/CImg.h
+++ b/src/CImg.h
@@ -27241,13 +27241,13 @@ namespace cimg_library {
         by = 3*(y1 - y0) - 2*v0 - v1,
         _precision = 1/(std::sqrt(cimg::sqr(x0-x1)+cimg::sqr(y0-y1))*(precision>0?precision:1));
       int ox = x0, oy = y0, otx = tx0, oty = ty0;
-      for (float t = 0; t<1; t+=_precision) {
-        const float t2 = t*t, t3 = t2*t;
+      for (float ti = 0; ti<1; ti+=_precision) {
+        const float t2 = ti*ti, t3 = t2*ti;
         const int
-          nx = (int)(ax*t3 + bx*t2 + u0*t + x0),
-          ny = (int)(ay*t3 + by*t2 + v0*t + y0),
-          ntx = tx0 + (int)((tx1-tx0)*t),
-          nty = ty0 + (int)((ty1-ty0)*t);
+          nx = (int)(ax*t3 + bx*t2 + u0*ti + x0),
+          ny = (int)(ay*t3 + by*t2 + v0*ti + y0),
+          ntx = tx0 + (int)((tx1-tx0)*ti),
+          nty = ty0 + (int)((ty1-ty0)*ti);
         draw_line(ox,oy,nx,ny,texture,otx,oty,ntx,nty,opacity,pattern,ninit_hatch);
         ninit_hatch = false;
         ox = nx; oy = ny; otx = ntx; oty = nty;

--- a/src/cimgffmpeg.cpp
+++ b/src/cimgffmpeg.cpp
@@ -39,11 +39,11 @@ void vfinfo_close(VFInfo  *vfinfo){
 int ReadFrames(VFInfo *st_info, CImgList<uint8_t> *pFrameList, unsigned int low_index, unsigned int hi_index)
 {
         //target pixel format
-	PixelFormat ffmpeg_pixfmt;
+	AVPixelFormat ffmpeg_pixfmt;
 	if (st_info->pixelformat == 0)
-	    ffmpeg_pixfmt = PIX_FMT_GRAY8;
+	    ffmpeg_pixfmt = AV_PIX_FMT_GRAY8;
 	else 
-	    ffmpeg_pixfmt = PIX_FMT_RGB24;
+	    ffmpeg_pixfmt = AV_PIX_FMT_RGB24;
 
 	st_info->next_index = low_index;
 
@@ -100,12 +100,12 @@ int ReadFrames(VFInfo *st_info, CImgList<uint8_t> *pFrameList, unsigned int low_
         AVFrame *pFrame;
 
 	// Allocate video frame
-	pFrame=avcodec_alloc_frame();
+	pFrame=av_frame_alloc();
 	if (pFrame==NULL)
 	    return -1;
 
 	// Allocate an AVFrame structure
-	AVFrame *pConvertedFrame = avcodec_alloc_frame();
+	AVFrame *pConvertedFrame = av_frame_alloc();
 	if(pConvertedFrame==NULL)
 	  return -1;
 		
@@ -123,7 +123,7 @@ int ReadFrames(VFInfo *st_info, CImgList<uint8_t> *pFrameList, unsigned int low_
 	int size = 0;
 	
 
-        int channels = ffmpeg_pixfmt == PIX_FMT_GRAY8 ? 1 : 3;
+        int channels = ffmpeg_pixfmt == AV_PIX_FMT_GRAY8 ? 1 : 3;
 
 	AVPacket packet;
 	int result = 1;
@@ -189,11 +189,11 @@ int ReadFrames(VFInfo *st_info, CImgList<uint8_t> *pFrameList, unsigned int low_
 
 int NextFrames(VFInfo *st_info, CImgList<uint8_t> *pFrameList)
 {
-        PixelFormat ffmpeg_pixfmt;
+        AVPixelFormat ffmpeg_pixfmt;
 	if (st_info->pixelformat == 0)
-	    ffmpeg_pixfmt = PIX_FMT_GRAY8;
+	  ffmpeg_pixfmt = AV_PIX_FMT_GRAY8;
         else 
-	    ffmpeg_pixfmt = PIX_FMT_RGB24;
+	  ffmpeg_pixfmt = AV_PIX_FMT_RGB24;
 
 	if (st_info->pFormatCtx == NULL)
 	{
@@ -254,10 +254,10 @@ int NextFrames(VFInfo *st_info, CImgList<uint8_t> *pFrameList)
 	AVFrame *pFrame;
 
 	// Allocate video frame
-	pFrame=avcodec_alloc_frame();
+	pFrame=av_frame_alloc();
 		
 	// Allocate an AVFrame structure
-	AVFrame *pConvertedFrame = avcodec_alloc_frame();
+	AVFrame *pConvertedFrame = av_frame_alloc();
 	if(pConvertedFrame==NULL){
 	  return -1;
 	}
@@ -287,7 +287,7 @@ int NextFrames(VFInfo *st_info, CImgList<uint8_t> *pFrameList)
 			break;
 		if(packet.stream_index == st_info->videoStream) {
 			
-		int channels = ffmpeg_pixfmt == PIX_FMT_GRAY8 ? 1 : 3;
+		int channels = ffmpeg_pixfmt == AV_PIX_FMT_GRAY8 ? 1 : 3;
  		AVPacket avpkt;
                 av_init_packet(&avpkt);
                 avpkt.data = packet.data;


### PR DESCRIPTION
This series fixes compilation with gcc-8.-3 and ffpmg 4.1. I also fixed the configure.ac scripts, but I guess that now CMake is the preferred build system. 

The source code for TestRadish is missing btw, and it would probably a good idea to get rid of the CImag.h file, or at least add the option to make sure that the system version is included if it is available. But that is for another pull request. 