### PR TITLE
Fix Travis CI build step for MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
         
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo apt-get install -y libpng-dev libjpeg-dev libtiff-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libsndfile1-dev libsamplerate0-dev libmpg123-dev; fi
-  - if [ $TRAVIS_OS_NAME == "osx" ]; then travis_retry brew upgrade && travis_retry brew install libpng libtiff libjpeg ffmpeg mpg123; fi
+  - if [ $TRAVIS_OS_NAME == "osx" ]; then travis_retry brew install libpng libtiff libjpeg ffmpeg mpg123; fi
 before_script:
   - mkdir -p build
   - cd build


### PR DESCRIPTION
`brew upgrade` fails on Mojave with multiple `Failed to download resource` and  `Xcode 11.4 cannot be installed on macOS 10.14. You must upgrade your version of macOS.`

This hotfix simply removes `brew upgrade` from the build script, but maybe a proper solution would be to upgrade [`osx_image`](https://github.com/aetilius/pHash/blob/master/.travis.yml#L14). 

Build examples
- [Failing](https://travis-ci.com/github/aetilius/pHash/jobs/499224738)
- [Passing](https://travis-ci.com/github/bitnot/pHash/jobs/524379152)

WDYT @aetilius ?