### PR TITLE
Fix Travis CI build for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 before_script:
   - mkdir -p build
   - cd build
-  - cmake -DWITH_AUDIO_HASH=1 -DWITH_VIDEO_HASH=1 ..
+  - cmake -DWITH_AUDIO_HASH=1 -DWITH_VIDEO_HASH=1 -DLIBDIR=lib ..
 script: make
 notifications:
   email: false


### PR DESCRIPTION
Follow up on 99bcd4d
Sets the `LIBDIR` variable to `lib`.

[Failing build](https://github.com/bitnot/pHash/runs/3861809127)
[Passing build](https://github.com/bitnot/pHash/runs/3861825744)