### PR TITLE
Replace custom rounding logic with std::round

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+1.0.1
+---
+Clean up rounding logic
+
 1.0
 ---
 GitHub release

--- a/pHash.xml
+++ b/pHash.xml
@@ -14,9 +14,9 @@
  </maintainers>
 
  <release>
-  <version>0.9.2</version>
-  <date>2013-04-23</date>
-<state>beta</state>
+  <version>1.0.1</version>
+  <date>2021-12-20</date>
+  <state>release</state>
  </release>
 
 <deps language="cpp" platform="all">

--- a/phash-win32/src/cimgffmpeg.cpp
+++ b/phash-win32/src/cimgffmpeg.cpp
@@ -1,5 +1,7 @@
 #include "cimgffmpeg.h"
 
+#include <cmath>
+
 __declspec(dllexport) void vfinfo_close(VFInfo *vfinfo) {
     if (vfinfo->pFormatCtx != NULL) {
         avcodec_close(vfinfo->pCodecCtx);
@@ -411,7 +413,7 @@ __declspec(dllexport) CImgList<uint8_t> *ph_getKeyFramesFromVideo(
         return NULL;
     }
 
-    int step = (int)(frames_per_sec + ROUNDING_FACTOR(frames_per_sec));
+    int step = std::round(frames_per_sec);
     long nbframes = (long)(N / step);
 
     float *dist = (float *)av_malloc((nbframes) * sizeof(float));

--- a/phash-win32/src/cimgffmpeg.h
+++ b/phash-win32/src/cimgffmpeg.h
@@ -2,7 +2,6 @@
 #define CIMGFFMPEG_H_
 
 #define cimg_display 0
-#define ROUNDING_FACTOR(x) (((x) >= 0) ? 0.5 : -0.5)
 
 #include "CImg.h"
 #include "string.h"

--- a/phash-win32/src/pHash.cpp
+++ b/phash-win32/src/pHash.cpp
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <windows.h>
+#include <cmath>
 #include <utility>
 #include "dirent.h"
 
@@ -57,8 +58,8 @@ __declspec(dllexport) int ph_radon_projections(const CImg<uint8_t> &img, int N,
     int D = (width > height) ? width : height;
     float x_center = (float)width / 2;
     float y_center = (float)height / 2;
-    int x_off = (int)std::floor(x_center + ROUNDING_FACTOR(x_center));
-    int y_off = (int)std::floor(y_center + ROUNDING_FACTOR(y_center));
+    int x_off = std::round(x_center);
+    int y_off = std::round(y_center);
 
     projs.R = new CImg<uint8_t>(N, D, 1, 1, 0);
     projs.nb_pix_perline = (int *)calloc(N, sizeof(int));
@@ -75,7 +76,7 @@ __declspec(dllexport) int ph_radon_projections(const CImg<uint8_t> &img, int N,
         double alpha = std::tan(theta);
         for (int x = 0; x < D; x++) {
             double y = alpha * (x - x_off);
-            int yd = (int)std::floor(y + ROUNDING_FACTOR(y));
+            int yd = std::round(y);
             if ((yd + y_off >= 0) && (yd + y_off < height) && (x < width)) {
                 *ptr_radon_map->data(k, x) = img(x, yd + y_off);
                 nb_per_line[k] += 1;
@@ -93,7 +94,7 @@ __declspec(dllexport) int ph_radon_projections(const CImg<uint8_t> &img, int N,
         double alpha = std::tan(theta);
         for (int x = 0; x < D; x++) {
             double y = alpha * (x - x_off);
-            int yd = (int)std::floor(y + ROUNDING_FACTOR(y));
+            int yd = std::round(y);
             if ((yd + y_off >= 0) && (yd + y_off < height) && (x < width)) {
                 *ptr_radon_map->data(k, x) = img(x, yd + y_off);
                 nb_per_line[k] += 1;

--- a/src/pHash.cpp
+++ b/src/pHash.cpp
@@ -27,6 +27,8 @@
 #include "cimgffmpeg.h"
 #endif
 
+#include <cmath>
+
 const char phash_project[] = "%s. Copyright 2008-2010 Aetilius, Inc.";
 char phash_version[255] = {0};
 const char *ph_about() {
@@ -43,8 +45,8 @@ int ph_radon_projections(const CImg<uint8_t> &img, int N, Projections &projs) {
     int D = (width > height) ? width : height;
     float x_center = (float)width / 2;
     float y_center = (float)height / 2;
-    int x_off = (int)std::floor(x_center + ROUNDING_FACTOR(x_center));
-    int y_off = (int)std::floor(y_center + ROUNDING_FACTOR(y_center));
+    int x_off = std::round(x_center);
+    int y_off = std::round(y_center);
 
     projs.R = new CImg<uint8_t>(N, D, 1, 1, 0);
     projs.nb_pix_perline = (int *)calloc(N, sizeof(int));
@@ -61,7 +63,7 @@ int ph_radon_projections(const CImg<uint8_t> &img, int N, Projections &projs) {
         double alpha = std::tan(theta);
         for (int x = 0; x < D; x++) {
             double y = alpha * (x - x_off);
-            int yd = (int)std::floor(y + ROUNDING_FACTOR(y));
+            int yd = std::round(y);
             if ((yd + y_off >= 0) && (yd + y_off < height) && (x < width)) {
                 *ptr_radon_map->data(k, x) = img(x, yd + y_off);
                 nb_per_line[k] += 1;
@@ -79,7 +81,7 @@ int ph_radon_projections(const CImg<uint8_t> &img, int N, Projections &projs) {
         double alpha = std::tan(theta);
         for (int x = 0; x < D; x++) {
             double y = alpha * (x - x_off);
-            int yd = (int)std::floor(y + ROUNDING_FACTOR(y));
+            int yd = std::round(y);
             if ((yd + y_off >= 0) && (yd + y_off < height) && (x < width)) {
                 *ptr_radon_map->data(k, x) = img(x, yd + y_off);
                 nb_per_line[k] += 1;
@@ -358,7 +360,7 @@ CImgList<uint8_t> *ph_getKeyFramesFromVideo(const char *filename) {
         return NULL;
     }
 
-    int step = (int)(frames_per_sec + ROUNDING_FACTOR(frames_per_sec));
+    int step = std::round(frames_per_sec);
     long nbframes = (long)(N / step);
     // If the video length is less than 1 the video is probably corrupted.
     if (nbframes <= 0) {

--- a/src/pHash.h.cmake
+++ b/src/pHash.h.cmake
@@ -82,8 +82,6 @@ using namespace std;
 #define ULLONG_MAX 18446744073709551615ULL
 #endif
 
-#define ROUNDING_FACTOR(x) (((x) >= 0) ? 0.5 : -0.5) 
-
 #if defined( _MSC_VER) || defined(_BORLANDC_)
 typedef unsigned _uint64 ulong64;
 typedef signed _int64 long64;


### PR DESCRIPTION
Below is a comparison of the results of the old and the new rounding behavior. There is no difference for non-negative numbers. Fixes #25.

 val  | old | new
 ---- | --- | ---
-1.5  | -2  | -2
-1.25 | -2  | -1
-1.0  | -2  | -1
-0.75 | -2  | -1
-0.5  | -1  | -1
-0.25 | -1  |  0
±0.0  |  0  |  0
 0.25 |  0  |  0
 0.5  |  1  |  1
 0.75 |  1  |  1
 1    |  1  |  1
 1.25 |  1  |  1
 1.5  |  2  |  2