### PR TITLE
Fix cmake error when including pHash library in another project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 find_path(CIMG_H_DIR NAMES CImg.h PATHS "${CMAKE_CURRENT_SOURCE_DIR}/third-party/CImg")
 include_directories(${CIMG_H_DIR})
 
-CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/src/pHash.h.cmake ${CMAKE_SOURCE_DIR}/src/pHash.h)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/src/pHash.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/src/pHash.h)
 
 
 if(NOT WIN32)


### PR DESCRIPTION
When I include pHash library in my project I get cmake errors like this:

```txt
CMake Error: File myProject/src/pHash.h.cmake does not exist.
CMake Error at myProject/phash-src/CMakeLists.txt:32 (CONFIGURE_FILE):
  CONFIGURE_FILE Problem configuring file
```

My cmake code to include the pHash library:
```cmake
FetchContent_Declare(
    pHash
    GIT_REPOSITORY https://github.com/aetilius/pHash.git
)
FetchContent_MakeAvailable(pHash)
include_directories("${pHash_SOURCE_DIR}/src")
include_directories("${pHash_SOURCE_DIR}/third-party/CImg")
```

With fix in this PR these errors are resolved.