### PR TITLE
Fix example buffer overflow, wrong-handle check, and header pollution

### DIFF
--- a/examples/test_imagephash.cpp
+++ b/examples/test_imagephash.cpp
@@ -24,6 +24,7 @@
 
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <algorithm>
 #include <vector>
@@ -86,63 +87,73 @@ int main(int argc, char **argv) {
     errno = 0;
     int i = 0;
     ulong64 tmphash;
-    char path[100];
-    path[0] = '\0';
+    char path[PATH_MAX];
     while ((dir_entry = readdir(dir)) != 0) {
         if (strcmp(dir_entry->d_name, ".") && strcmp(dir_entry->d_name, "..")) {
-            strcat(path, dir_name);
-            strcat(path, "/");
-            strcat(path, dir_entry->d_name);
-            if (ph_dct_imagehash(path, tmphash) < 0)  // calculate the hash
+            int n = snprintf(path, sizeof(path), "%s/%s", dir_name,
+                             dir_entry->d_name);
+            if (n < 0 || (size_t)n >= sizeof(path)) {
+                fprintf(stderr, "path too long, skipping %s\n",
+                        dir_entry->d_name);
+                errno = 0;
                 continue;
-            dp = ph_malloc_imagepoint();  // store in structure with file name
+            }
+            if (ph_dct_imagehash(path, tmphash) < 0)
+                continue;
+            dp = ph_malloc_imagepoint();
             dp->id = dir_entry->d_name;
             dp->hash = tmphash;
             hashlist1.push_back(*dp);
             i++;
         }
         errno = 0;
-        path[0] = '\0';
     }
 
     if (errno) {
         printf("error reading directory\n");
+        closedir(dir);
         exit(1);
     }
+    closedir(dir);
 
     sort(hashlist1.begin(), hashlist1.end(), cmp_lt_imp);
 
     // second directory
     dir_entry = NULL;
     DIR *dir2 = opendir(dir_name2);
-    if (!dir) {
+    if (!dir2) {
         printf("unable to open directory\n");
         exit(1);
     }
     errno = 0;
-    path[0] = '\0';
     i = 0;
     while ((dir_entry = readdir(dir2)) != 0) {
         if (strcmp(dir_entry->d_name, ".") && strcmp(dir_entry->d_name, "..")) {
-            strcat(path, dir_name2);
-            strcat(path, "/");
-            strcat(path, dir_entry->d_name);
-            if (ph_dct_imagehash(path, tmphash) < 0)  // calculate the hash
+            int n = snprintf(path, sizeof(path), "%s/%s", dir_name2,
+                             dir_entry->d_name);
+            if (n < 0 || (size_t)n >= sizeof(path)) {
+                fprintf(stderr, "path too long, skipping %s\n",
+                        dir_entry->d_name);
+                errno = 0;
                 continue;
-            dp = ph_malloc_imagepoint();  // store in structure with filename
+            }
+            if (ph_dct_imagehash(path, tmphash) < 0)
+                continue;
+            dp = ph_malloc_imagepoint();
             dp->id = dir_entry->d_name;
             dp->hash = tmphash;
             hashlist2.push_back(*dp);
             i++;
         }
         errno = 0;
-        path[0] = '\0';
     }
 
     if (errno) {
         printf("error reading directory\n");
+        closedir(dir2);
         exit(1);
     }
+    closedir(dir2);
 
     sort(hashlist2.begin(), hashlist2.end(), cmp_lt_imp);
 

--- a/src/pHash.h.cmake
+++ b/src/pHash.h.cmake
@@ -74,7 +74,10 @@ using namespace cimg_library;
 
 #endif
 
-using namespace std;
+// Note: a `using namespace std;` used to live here, polluting every
+// translation unit that included pHash.h. It has been removed since none
+// of the declarations in this header actually depend on std::. Callers
+// that relied on it can add their own `using namespace std;` locally.
 
 #define SQRT_TWO 1.4142135623730950488016887242097
 
@@ -233,7 +236,10 @@ int ph_dct_imagehash(const char* file,ulong64 &hash);
 
 
 #ifdef HAVE_VIDEO_HASH
-static CImgList<uint8_t>* ph_getKeyFramesFromVideo(const char *filename);
+// Note: this used to be declared `static` here while being defined as an
+// extern symbol in pHash.cpp -- a one-definition-rule landmine. The function
+// is an implementation detail of ph_dct_videohash and is not exposed.
+CImgList<uint8_t>* ph_getKeyFramesFromVideo(const char *filename);
 
 ulong64* ph_dct_videohash(const char *filename, int &Length);
 


### PR DESCRIPTION
Fixes a stack-buffer overflow, a wrong-handle check, and removes header namespace pollution: audit findings #24, #25, #28 (second half).

## Examples (`test_imagephash.cpp`)

- **#24** The `path` buffer was `char path[100]` and was filled with three unbounded `strcat()` calls (`dir_name`, `"/"`, `d_name`). A long `argv[1]` or a long filename would smash the stack. Replaced with `PATH_MAX` and `snprintf`, with a length check that skips entries too long to fit; the function no longer assumes `path[]` is large enough.
- **#25** The second-directory open path was:
  ```cpp
  DIR *dir2 = opendir(dir_name2);
  if (!dir) { ... }
  ```
  i.e. it checked the **first** handle, not the one it just opened. If `dir_name2` is absent the program then ran `readdir(NULL)` and crashed. Now correctly tests `dir2`.
- Closes both `DIR*` handles on every exit path (the old code leaked them on success and at least one error path).
- Includes `<limits.h>` for `PATH_MAX`.

## Public header (`pHash.h.cmake`)

- **#28** Removed `using namespace std;` from the public header. None of pHash.h's own declarations depend on `std::`, so this only ever served to dump the std namespace into every translation unit that included the library. Callers that relied on it can add their own `using namespace std;` locally.
- `ph_getKeyFramesFromVideo` was declared `static` in the header while being defined as an extern symbol in `pHash.cpp` — an ODR hazard. Removed the `static` qualifier on the declaration.

## Test plan

- [x] `test_imagephash` compiles and runs against directories of perturbed PNGs, producing intra/inter Hamming distances
- [x] All other examples (`test_radish`, `test_mhimagehash`, `test_texthash`, `test_audiophash`, `test_dctvideohash`) still compile with the modified header — none of them needed `using namespace std;` from `pHash.h` (they each have their own `using` statements where needed)
