### PR TITLE
Align DCT image hash with canonical pHash convention (breaking)

### DIFF
--- a/src/pHash.cpp
+++ b/src/pHash.cpp
@@ -392,11 +392,22 @@ int ph_dct_imagehash(const char *file, ulong64 &hash) {
 
     CImg<float> dctImage = C * img * Ctransp;
 
-    CImg<float> subsec = dctImage.crop(1, 1, 8, 8).unroll('x');
+    // Canonical pHash (Krawetz "Looks Like It" / Zauner 2010): take the
+    // top-left 8x8 block of the DCT and bit-test each coefficient against
+    // the median of the *other 63*, excluding the DC term at (0,0).
+    //
+    // Earlier versions of this code took (1,1)..(8,8), skipping the entire
+    // first row and column of low frequencies (incompatible with every
+    // other library that calls itself pHash), then took the median over
+    // all 64 values. Including DC in the median was problematic too:
+    // |DC| is typically 10-100x larger than any AC coefficient, so its
+    // hash bit was effectively always 1, wasting one of the 64 hash bits.
+    CImg<float> subsec = dctImage.crop(0, 0, 7, 7).unroll('x');
 
-    float median = subsec.median();
-    // Build hash so that sample i lives in bit (63 - i). The previous version
-    // shifted *after* every iteration including the last, dropping bit 0.
+    // Median of the 63 AC coefficients (positions 1..63). Skipping DC
+    // here means none of the 64 emitted bits is a foregone conclusion.
+    CImg<float> ac = subsec.get_crop(1, 0, 0, 0, 63, 0, 0, 0);
+    float median = ac.median();
     hash = 0;
     for (int i = 0; i < 64; i++) {
         if (subsec(i) > median) hash |= 0x01;
@@ -615,8 +626,11 @@ ulong64 *ph_dct_videohash(const char *filename, int &Length) {
         currentframe = keyframes->at(i);
         currentframe.blur(1.0);
         dctImage = C * currentframe * Ctransp;
-        subsec = dctImage.crop(1, 1, 8, 8).unroll('x');
-        float med = subsec.median();
+        // Match ph_dct_imagehash: canonical top-left 8x8 of the DCT,
+        // median over the 63 AC coefficients (skip DC at position 0).
+        subsec = dctImage.crop(0, 0, 7, 7).unroll('x');
+        CImg<float> ac = subsec.get_crop(1, 0, 0, 0, 63, 0, 0, 0);
+        float med = ac.median();
         hash[i] = 0x0000000000000000;
         ulong64 one = 0x0000000000000001;
         for (int j = 0; j < 64; j++) {


### PR DESCRIPTION
Aligns `ph_dct_imagehash` and `ph_dct_videohash` with the canonical pHash specification (Krawetz "Looks Like It" / Zauner 2010). Addresses the deviation noted in §1 of the algorithmic-correctness assessment.

> **Stacked on top of #48 (`fix/image-hash`).** Merge #48 first, or re-target this PR at `master` after #48 lands.

## What was wrong

`ph_dct_imagehash` and `ph_dct_videohash` took the 8×8 low-frequency DCT sub-block at positions `(1,1)..(8,8)`. That skips the entire first row **and** column of the DCT, not just the DC term, and produces hashes that bit-mismatch every other library calling itself pHash (python-imagehash, the python bindings, perceptual-hash-go, etc.).

## What this PR does

- The 8×8 block is now the canonical top-left `(0,0)..(7,7)`.
- The threshold is the median of the 63 AC coefficients (positions 1..63 after unrolling), excluding DC. Including DC in the median was problematic on principle — `|DC|` is typically 10–100× larger than any AC coefficient — though in practice DC sits at sorted position 63, so the median value is essentially identical either way.
- All 64 coefficients (including DC) are bit-tested against that threshold. DC's bit is therefore effectively always `1`, which is the cost of preserving a 64-bit hash word. Trading that bit away to gain compatibility with the rest of the ecosystem is the right call; if you ever want to reclaim it, that's a separate, more invasive convention change.

## Compatibility

**This is a binary-incompatible hash change.** Callers that have indexed pHash values produced by this library will need to recompute them. The new values match the Krawetz convention but **do not** bit-match python-imagehash exactly (python-imagehash takes the median over all 64; this PR over 63 AC). The difference is marginal in practice.

## Test plan

- [x] Hash stability: same input produces the same 64-bit hash on repeated calls
- [x] DC bit verification: `pHash.png` → `0xfe4ac1a4...`, leading nibble `0xf` confirms DC-and-low-frequency bits dominate, as expected
- [x] Across 5 test images bit 0 takes both 0 and 1 values (the bug #1 fix from #48 is still effective)
