### PR TITLE
Align audio hash params with Haitsma-Kalker reference (breaking)

### DIFF
--- a/src/audiophash.cpp
+++ b/src/audiophash.cpp
@@ -335,16 +335,32 @@ float *ph_readaudio(const char *filename, int sr, int /*channels*/,
     return ph_readaudio2(filename, sr, sigbuf, buflen, nbsecs);
 }
 
+// Round target up to the nearest power of 2, then choose whichever of
+// {that, that/2} is closer to target. Used to size FFT frames given a
+// target duration. The custom radix-2 FFT in ph_fft requires a power
+// of 2.
+static int closest_pow2(double target) {
+    if (target <= 1.0) return 1;
+    int p = 1;
+    while ((double)p < target) p *= 2;
+    int prev = p / 2;
+    return (target - (double)prev) > ((double)p - target) ? p : prev;
+}
+
 uint32_t *ph_audiohash(float *buf, int N, int sr, int &nb_frames) {
     nb_frames = 0;
-    const int frame_length = 4096;
-    const int nfft = frame_length;
-    const int nfft_half = 2048;
-    if (buf == NULL || N < frame_length || sr <= 0) return NULL;
+    if (buf == NULL || sr <= 0) return NULL;
 
-    const int overlap = 31 * frame_length / 32;
-    const int advance = frame_length - overlap;
-    if (advance <= 0) return NULL;
+    // Haitsma-Kalker parameters: 0.37 s frames, 31.25 frames/sec
+    // (i.e. ~32 ms advance). Frame size is rounded to a power of 2
+    // because the bundled FFT is radix-2.
+    const int frame_length = closest_pow2((double)sr * 0.37);
+    const int nfft = frame_length;
+    const int nfft_half = frame_length / 2;
+    if (N < frame_length) return NULL;
+
+    int advance = (int)std::round((double)sr / 31.25);
+    if (advance <= 0) advance = 1;
 
     nb_frames = (N - frame_length) / advance + 1;
     if (nb_frames <= 0) {
@@ -361,8 +377,11 @@ uint32_t *ph_audiohash(float *buf, int N, int sr, int &nb_frames) {
     std::vector<std::complex<double>> pF(nfft);
     std::vector<double> magnF(nfft_half);
 
+    // Haitsma-Kalker: 33 log-spaced bands from 300 to 2000 Hz. The
+    // previous value of 3000 Hz extended the upper band by 1 kHz beyond
+    // the paper.
     const double minfreq = 300;
-    const double maxfreq = 3000;
+    const double maxfreq = 2000;
     const double minbark = 6 * asinh(minfreq / 600.0);
     const double maxbark = 6 * asinh(maxfreq / 600.0);
     const double nyqbark = maxbark - minbark;


### PR DESCRIPTION
Aligns the time-domain and frequency-domain parameters of `ph_audiohash` with Haitsma-Kalker 2002 ("A Highly Robust Audio Fingerprinting System"). Addresses §4 of the algorithmic-correctness assessment.

> **Stacked on top of #49 (`fix/audio-hash`).** Merge #49 first, or re-target this PR at `master` after #49 lands.

## What was wrong

The bit derivation, filterbank shape, and confidence score in `ph_audiohash` already matched Haitsma-Kalker, but several parameters did not:

- `frame_length` was hard-coded to 4096 samples regardless of sample rate. At the example's `sr=8000` that is 512 ms, far from the paper's 0.37 s frame.
- Frame advance was `frame_length / 32` (~97% overlap), giving ~62 frames/sec at `sr=8000`. The paper specifies 31.25 frames/sec (~32 ms advance).
- `maxfreq` was 3000 Hz; the paper specifies 2000 Hz. The previous range extended the upper band by 1 kHz beyond Haitsma-Kalker.

## What this PR does

- `frame_length` is now derived as the power of 2 closest to `sr * 0.37` (the radix-2 FFT requires a power of 2).
- Advance is now `round(sr / 31.25)`.
- `maxfreq` is now 2000 Hz.
- `nfft_half` is now `frame_length / 2` (was hard-coded `2048`).

The bit derivation and filter weights are unchanged.

## Compatibility

**Binary-incompatible hash change.** Hashes produced by this code are not compatible with hashes produced by the old parameters.

This also changes the **temporal density** of the fingerprint. Callers passing `block_size` to `ph_audio_distance_ber` will likely want a smaller value (e.g. 64 instead of the example's 256) because the absolute frame count for the same audio drops by ~2× — the example value of 256 will produce M=0 blocks and a `cs = 0.5` (neutral) confidence on short signals.

## Verification

- Identical 5 s 440 Hz sines, `block_size = 64`: `cs = 1.000000`
- 440 Hz vs 441 Hz, `block_size = 64`: `cs = 0.251` (low similarity, as expected)

## Test plan

- [x] Compiles clean (`-Wall`) with `HAVE_AUDIO_HASH` + `HAVE_LIBMPG123`
- [x] `test_audiophash -f a.wav -g a.wav -b 64`: confidence 1.0
- [x] `test_audiophash -f 440.wav -g 441.wav -b 64`: confidence ~0.25
