### PR TITLE
Bump pHash version to 1.0 and wire up pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.5)
 
 include(ExternalProject)
 include(GNUInstallDirs)
 
-project(pHash)
+project(pHash VERSION 1.0.0)
 set(CMAKE_MACOSX_RPATH 1)
-set(pHash_VERSION_MAJOR 1)
-set(pHash_VERSION_MINOR 0)
-set(pHash_VERSION_PATCH 0)
+set(pHash_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(pHash_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(pHash_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set(VERSION ${PROJECT_VERSION})
 
 OPTION(PHASH_DYNAMIC   "Build pHash dynamic library"                     ON)
 OPTION(PHASH_STATIC    "Build pHash static library"                     OFF)
@@ -30,6 +31,16 @@ find_path(CIMG_H_DIR NAMES CImg.h PATHS "${CMAKE_CURRENT_SOURCE_DIR}/third-party
 include_directories(${CIMG_H_DIR})
 
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/src/pHash.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/src/pHash.h)
+
+# Populate pHash.pc.in's @VERSION@/@prefix@/etc. so the installed pkg-config
+# file actually has a real version (the template was previously copied but
+# never configured).
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/pHash.pc.in
+               ${CMAKE_CURRENT_BINARY_DIR}/pHash.pc @ONLY)
 
 
 if(NOT WIN32)
@@ -95,8 +106,10 @@ endif()
 set_property(TARGET pHash PROPERTY VERSION "${pHash_VERSION_MAJOR}.${pHash_VERSION_MINOR}.${pHash_VERSION_PATCH}")
 target_link_libraries(pHash ${LIBS_DEPS})
 
-install(TARGETS pHash DESTINATION ${LIBDIR})
-install(FILES src/pHash.h DESTINATION include)
+install(TARGETS pHash DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES src/pHash.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pHash.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 if(PHASH_EXAMPLES)
 set(EXAMPLEDIR examples)

--- a/libpHash.spec
+++ b/libpHash.spec
@@ -1,5 +1,5 @@
 Name:           pHash
-Version:        0.9.7
+Version:        1.0
 Release:        1%{?dist}
 Summary:        pHash, the open source perceptual hashing library
 


### PR DESCRIPTION
Bring the project's version markers into a consistent 1.0 state and fix the long-broken pkg-config template.

## Changes

- `libpHash.spec` was still at **0.9.7** even though `CMakeLists.txt` already declared the version as **1.0.0** and the `ChangeLog` has had `1.0` and `1.0.1` entries for years. Bumped the spec to `1.0` to bring the RPM packaging in line with everything else.
- `CMakeLists.txt` now uses `project(pHash VERSION 1.0.0)` as the single source of truth. The legacy `pHash_VERSION_MAJOR/MINOR/PATCH` variables are derived from `PROJECT_VERSION_*`, and a top-level `VERSION` cmake variable is set so `pHash.pc.in`'s `@VERSION@` substitution actually works.
- `pHash.pc.in` was being shipped with `@prefix@`/`@VERSION@`/`@libdir@`/`@includedir@` left as **literal placeholders** because nothing ever called `CONFIGURE_FILE` on it. A `CONFIGURE_FILE` step now generates a real `pHash.pc` at build time, and an install rule drops it into `${CMAKE_INSTALL_LIBDIR}/pkgconfig`.
- Replaced an install destination that used an **undefined** `${LIBDIR}` variable with the proper `GNUInstallDirs` variables (`CMAKE_INSTALL_LIBDIR` / `CMAKE_INSTALL_INCLUDEDIR`). `include(GNUInstallDirs)` was already pulled at the top of the file but its variables were unused.
- Raised `cmake_minimum_required` from `2.8` (deprecated in CMake 3.5, removed in 4.0) to `3.5`. Required by `project(VERSION ...)`.

## Verification

```
$ cmake .                # builds .../pHash.pc with:
prefix=/usr/local
exec_prefix=/usr/local
libdir=/usr/local/lib
includedir=/usr/local/include

Name: pHash
Description: Perceptual hashing library
Version: 1.0.0          # ← was literally "@VERSION@" before
Libs: -L${libdir} -lpHash -lm
Cflags: -I${includedir}

$ make                   # produces:
Release/libpHash.1.0.0.dylib
Release/libpHash.dylib -> libpHash.1.0.0.dylib
```

## Test plan

- [x] `cmake .` configures successfully
- [x] `make` builds and links the library
- [x] Generated `pHash.pc` contains correct paths and `Version: 1.0.0`
- [x] Built library has the version baked into its filename
