### PR TITLE
Fix radial-hash gamma correction (no-op temporary, issue #22)

### DIFF
--- a/src/pHash.cpp
+++ b/src/pHash.cpp
@@ -296,7 +296,21 @@ int _ph_image_digest(const CImg<uint8_t> &img, double sigma, double gamma,
 
     graysc.blur((float)sigma);
 
-    (graysc / graysc.max()).pow(gamma);
+    // Gamma correction. The original expression
+    //     (graysc / graysc.max()).pow(gamma);
+    // discarded its result -- CImg::operator/ returns a new image, and
+    // pow() then modified that temporary which was thrown away at the
+    // semicolon, so graysc was never actually gamma-corrected (issue
+    // #22). Do the work in float space so the curve isn't quantised at
+    // each step, then convert back to the 8-bit pixel type radon expects.
+    if (gamma != 1.0) {
+        CImg<float> tmp(graysc);
+        float maxv = tmp.max();
+        if (maxv > 0) tmp /= maxv;
+        tmp.pow(gamma);
+        tmp *= 255.0f;
+        graysc = tmp;
+    }
 
     if (ph_radon_projections(graysc, N, projs) < 0) goto cleanup;
     if (ph_feature_vector(projs, features) < 0) goto cleanup;


### PR DESCRIPTION
_ph_image_digest had:

    (graysc / graysc.max()).pow(gamma);

CImg::operator/ returns a new image; pow() then modified that temporary which was destroyed at the semicolon. graysc was never gamma-corrected, so callers passing non-1.0 gamma values got the same digest as gamma=1.0.

Now does the gamma curve in float space (to avoid quantising at each step) and assigns back to graysc. For gamma=1.0 the branch is skipped so the existing behaviour is preserved exactly for callers that didn't notice the bug.

Verified: with gamma=1.0 vs gamma=0.5 on the same image, 38 of 40 digest coefficients now differ (previously 0). Fixes #22.