### PR TITLE
Add container-duration fallback for MKV/WebM frame counts (closes #36)

### DIFF
--- a/src/cimgffmpeg.cpp
+++ b/src/cimgffmpeg.cpp
@@ -272,6 +272,20 @@ long GetNumberVideoFrames(const char *file) {
                 int timebase = str->time_base.den / str->time_base.num;
                 if (timebase > 0) nb_frames = str->duration / timebase;
             }
+            // Container-level fallback for formats whose stream metadata
+            // does not carry per-stream frame counts or durations -- most
+            // notably MKV and WebM, which only record container-level
+            // duration. Compute frame count from container duration *
+            // average frame rate (issue #36).
+            if (nb_frames <= 0 &&
+                pFormatCtx->duration > 0 &&
+                str->avg_frame_rate.num > 0 &&
+                str->avg_frame_rate.den > 0) {
+                nb_frames = (long)((double)pFormatCtx->duration *
+                                   str->avg_frame_rate.num /
+                                   (double)str->avg_frame_rate.den /
+                                   (double)AV_TIME_BASE);
+            }
         }
     }
 


### PR DESCRIPTION
## Bug

`GetNumberVideoFrames` only consulted per-stream metadata: stream `nb_frames`, then `av_index_search_timestamp`, then per-stream `duration / time_base`. MKV and WebM containers do not carry any of these in their stream headers, so every fallback returned `<= 0` and `ph_dct_videohash` bailed out before doing any work.

## Fix

Add a fourth fallback using container-level `pFormatCtx->duration` combined with the stream `avg_frame_rate`, which both MKV and WebM do expose. Matches the approach in the StackOverflow answer the original issue referenced.

## Verification

Synthesised clips, 3 seconds @ 10 fps:

```
/tmp/clip.mkv:  30 frames
/tmp/clip.webm: 30 frames
/tmp/clip.mp4:  30 frames   (unchanged)
```

Pre-fix the MKV and WebM cases returned `-1`.

Closes #36.