### PR TITLE
Add HEIF / HEIC / AVIF image support via libheif (closes #18)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ OPTION(PHASH_DYNAMIC   "Build pHash dynamic library"                     ON)
 OPTION(PHASH_STATIC    "Build pHash static library"                     OFF)
 OPTION(WITH_AUDIO_HASH "Audio hash support"                             OFF)
 OPTION(WITH_VIDEO_HASH "Video hash support"                             OFF)
+OPTION(WITH_HEIF       "HEIF/HEIC/AVIF image support via libheif"       OFF)
 OPTION(PHASH_BINDINGS  "Compile foreign programming languages bindings" OFF)
 OPTION(PHASH_EXAMPLES  "Compile examples"                               OFF)
 
@@ -25,6 +26,33 @@ endif()
 
 if(WITH_VIDEO_HASH)
     set(HAVE_VIDEO_HASH 1)
+endif()
+
+if(WITH_HEIF)
+    find_package(PkgConfig)
+    if(PKG_CONFIG_FOUND)
+        pkg_check_modules(LIBHEIF libheif)
+    endif()
+    if(NOT LIBHEIF_FOUND)
+        # Fallback: look for the header and library directly under common
+        # prefixes. libheif's pkg-config is sometimes missing on Linux
+        # distros that ship the package as `libheif-dev`.
+        find_path(LIBHEIF_INCLUDE_DIRS libheif/heif.h
+                  PATHS /opt/homebrew/include /usr/local/include /usr/include)
+        find_library(LIBHEIF_LIBRARIES NAMES heif libheif
+                     PATHS /opt/homebrew/lib /usr/local/lib /usr/lib)
+        if(LIBHEIF_INCLUDE_DIRS AND LIBHEIF_LIBRARIES)
+            set(LIBHEIF_FOUND TRUE)
+        endif()
+    endif()
+    if(NOT LIBHEIF_FOUND)
+        message(FATAL_ERROR
+            "WITH_HEIF=ON but libheif could not be located. "
+            "Install libheif (Homebrew: `brew install libheif`, "
+            "Debian: `apt install libheif-dev`) or set -DWITH_HEIF=OFF.")
+    endif()
+    set(HAVE_HEIF 1)
+    message(STATUS "libheif found: ${LIBHEIF_INCLUDE_DIRS} ${LIBHEIF_LIBRARIES}")
 endif()
 
 find_path(CIMG_H_DIR NAMES CImg.h PATHS "${CMAKE_CURRENT_SOURCE_DIR}/third-party/CImg")
@@ -102,6 +130,17 @@ if(HAVE_VIDEO_HASH)
     set(LIBS_DEPS ${LIBS_DEPS} avcodec avformat swscale avutil)
 endif()
 
+# ph_heif.cpp is always compiled (it carries the ph_is_heif_path
+# extension probe, which the load_image helper in pHash.cpp needs to
+# distinguish HEIF paths). The libheif-using body inside it is gated
+# behind HAVE_HEIF in the source, so the file builds cleanly even when
+# libheif isn't installed.
+list(APPEND EXTRA_SRC src/ph_heif.cpp)
+if(HAVE_HEIF)
+    include_directories(${LIBHEIF_INCLUDE_DIRS})
+    list(APPEND LIBS_DEPS ${LIBHEIF_LIBRARIES})
+endif()
+
 
 if(PHASH_DYNAMIC)
 	add_library(pHash SHARED ${MMAN_FILE} ${DIRENT_FILE} src/pHash.cpp ${EXTRA_SRC})
@@ -120,6 +159,7 @@ install(FILES src/pHash.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 # CImg<> *). Consumers therefore need CImg.h on their include path; ship
 # the bundled copy alongside.
 install(FILES ${CIMG_H_DIR}/CImg.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES src/ph_heif.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 if(HAVE_AUDIO_HASH)
     install(FILES src/audiophash.h src/ph_fft.h
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ int main(int argc, char **argv) {
 | **Image hash** | Always (HAVE_IMAGE_HASH=ON by default) | `libpng-dev libjpeg-dev libtiff-dev`                                                           | `libpng libtiff libjpeg` |
 | **Video hash** | `-DWITH_VIDEO_HASH=ON`   | `libavcodec-dev libavformat-dev libavutil-dev libswscale-dev`                                  | `ffmpeg` |
 | **Audio hash** | `-DWITH_AUDIO_HASH=ON`   | `libsndfile1-dev libsamplerate0-dev libmpg123-dev`                                             | `libsndfile libsamplerate mpg123` |
+| **HEIF/HEIC/AVIF** | `-DWITH_HEIF=ON`     | `libheif-dev`                                                                                  | `libheif` |
 | **Threads**    | Always                   | pthreads from the standard libc                                                                | — (built-in) |
 
 Note: pHash bundles [CImg](http://cimg.eu/) in `third-party/CImg/` — no separate install needed.
@@ -154,6 +155,7 @@ FFmpeg **5, 6, 7, and 8** are all supported.
 | `PHASH_STATIC`          | `OFF`   | Build the static library |
 | `WITH_AUDIO_HASH`       | `OFF`   | Compile `audiophash.cpp` and the audio hash API |
 | `WITH_VIDEO_HASH`       | `OFF`   | Compile `cimgffmpeg.cpp` and the video hash API |
+| `WITH_HEIF`             | `OFF`   | Decode `.heic` / `.heif` / `.avif` via libheif (issue #18) |
 | `PHASH_EXAMPLES`        | `OFF`   | Build the `TestDCT` / `TestRadish` / etc. demos |
 | `PHASH_BINDINGS`        | `OFF`   | Build language bindings (Java/C#/PHP) |
 

--- a/src/pHash.cpp
+++ b/src/pHash.cpp
@@ -26,10 +26,34 @@
 #ifdef HAVE_VIDEO_HASH
 #include "cimgffmpeg.h"
 #endif
+#include "ph_heif.h"
 
 #include <cmath>
 #include <map>
 #include <vector>
+
+namespace {
+
+// Single entry point for "load any supported image file into a
+// CImg<uint8_t>". HEIF/HEIC/AVIF files are routed to libheif (when
+// HAVE_HEIF is defined); everything else goes through CImg's own loader
+// (libpng / libjpeg / libtiff). Returns 0 on success, non-zero on
+// failure. CImg::load can still throw on truly malformed input -- callers
+// should wrap the call in try/catch.
+int load_image(const char *file, CImg<uint8_t> &img) {
+    if (file == NULL) return -1;
+    if (ph_is_heif_path(file)) {
+#ifdef HAVE_HEIF
+        return ph_load_heif(file, img);
+#else
+        return -1;  // HEIF path but library wasn't built with libheif
+#endif
+    }
+    img.load(file);
+    return 0;
+}
+
+}  // namespace
 
 const char phash_project[] = "%s. Copyright 2008-2010 Aetilius, Inc.";
 char phash_version[255] = {0};
@@ -331,7 +355,8 @@ int ph_image_digest(const char *file, double sigma, double gamma,
                     Digest &digest, int N) {
     if (file == NULL) return -1;
     try {
-        CImg<uint8_t> src(file);
+        CImg<uint8_t> src;
+        if (load_image(file, src) < 0) return -1;
         return _ph_image_digest(src, sigma, gamma, digest, N);
     } catch (CImgIOException &) {
         return -1;
@@ -363,8 +388,9 @@ int ph_compare_images(const char *file1, const char *file2, double &pcc,
                       double sigma, double gamma, int N, double threshold) {
     if (file1 == NULL || file2 == NULL) return -1;
     try {
-        CImg<uint8_t> imA(file1);
-        CImg<uint8_t> imB(file2);
+        CImg<uint8_t> imA, imB;
+        if (load_image(file1, imA) < 0) return -1;
+        if (load_image(file2, imB) < 0) return -1;
         return _ph_compare_images(imA, imB, pcc, sigma, gamma, N, threshold);
     } catch (CImgIOException &) {
         return -1;
@@ -398,7 +424,7 @@ int ph_dct_imagehash(const char *file, ulong64 &hash) {
     }
     CImg<uint8_t> src;
     try {
-        src.load(file);
+        if (load_image(file, src) < 0) return -1;
     } catch (CImgIOException &) {
         return -1;
     } catch (CImgException &) {
@@ -755,7 +781,7 @@ uint8_t *ph_mh_imagehash(const char *filename, int &N, float alpha, float lvl) {
 
     CImg<uint8_t> src;
     try {
-        src.load(filename);
+        if (load_image(filename, src) < 0) return NULL;
     } catch (CImgIOException &) {
         return NULL;
     } catch (CImgException &) {

--- a/src/pHash.h.cmake
+++ b/src/pHash.h.cmake
@@ -46,6 +46,7 @@
 #cmakedefine HAVE_IMAGE_HASH
 #cmakedefine HAVE_AUDIO_HASH
 #cmakedefine HAVE_VIDEO_HASH
+#cmakedefine HAVE_HEIF
 #cmakedefine HAVE_LIBMPG123
 #cmakedefine HAVE_SYS_SYSCTL_H
 

--- a/src/ph_heif.cpp
+++ b/src/ph_heif.cpp
@@ -1,0 +1,95 @@
+/*
+
+    pHash, the open source perceptual hash library
+    Copyright (C) 2009 Aetilius, Inc.
+
+    HEIF / HEIC / AVIF support via libheif (issue #18).
+
+*/
+
+#include "ph_heif.h"
+// pHash.h carries the CMake-generated HAVE_HEIF #define. Without this
+// include, the libheif-using body below would be silently compiled out
+// even when WITH_HEIF=ON, and the link of pHash.cpp -> ph_load_heif
+// would fail with an undefined symbol.
+#include "pHash.h"
+
+#include <strings.h>
+
+extern "C" int ph_is_heif_path(const char *file) {
+    if (file == NULL) return 0;
+    const char *dot = strrchr(file, '.');
+    if (dot == NULL) return 0;
+    return strcasecmp(dot, ".heic") == 0 ||
+           strcasecmp(dot, ".heif") == 0 ||
+           strcasecmp(dot, ".avif") == 0;
+}
+
+#ifdef HAVE_HEIF
+
+#include <libheif/heif.h>
+
+using cimg_library::CImg;
+
+int ph_load_heif(const char *file, CImg<uint8_t> &img) {
+    if (file == NULL) return -1;
+
+    heif_context *ctx = heif_context_alloc();
+    if (ctx == NULL) return -1;
+
+    heif_image_handle *handle = NULL;
+    heif_image *himg = NULL;
+    int rc = -1;
+
+    if (heif_context_read_from_file(ctx, file, NULL).code != heif_error_Ok)
+        goto cleanup;
+    if (heif_context_get_primary_image_handle(ctx, &handle).code !=
+        heif_error_Ok)
+        goto cleanup;
+
+    // Decode to interleaved 24-bit RGB. libheif handles the YUV-to-RGB
+    // conversion (including 10-bit HEVC sources downsampled to 8-bit),
+    // alpha discard, and orientation -- callers receive the same RGB
+    // bytes they'd get from libpng / libjpeg.
+    if (heif_decode_image(handle, &himg, heif_colorspace_RGB,
+                          heif_chroma_interleaved_RGB, NULL)
+            .code != heif_error_Ok)
+        goto cleanup;
+
+    {
+        int width = heif_image_get_width(himg, heif_channel_interleaved);
+        int height = heif_image_get_height(himg, heif_channel_interleaved);
+        if (width <= 0 || height <= 0) goto cleanup;
+
+        int stride = 0;
+        const uint8_t *plane = heif_image_get_plane_readonly(
+            himg, heif_channel_interleaved, &stride);
+        if (plane == NULL || stride < width * 3) goto cleanup;
+
+        // libheif gives interleaved RGB; CImg stores planar. Build an
+        // (channels, width, height) buffer then permute to the standard
+        // (width, height, depth=1, channels) layout -- same trick used by
+        // cimgffmpeg.cpp for FFmpeg-decoded frames.
+        try {
+            CImg<uint8_t> interleaved(3, width, height, 1, 0);
+            for (int y = 0; y < height; y++) {
+                const uint8_t *src = plane + (size_t)y * stride;
+                uint8_t *dst = interleaved.data(0, 0, y, 0);
+                for (int x = 0; x < width * 3; x++) dst[x] = src[x];
+            }
+            img = interleaved.get_permute_axes("yzcx");
+        } catch (...) {
+            goto cleanup;
+        }
+
+        rc = 0;
+    }
+
+cleanup:
+    if (himg) heif_image_release(himg);
+    if (handle) heif_image_handle_release(handle);
+    heif_context_free(ctx);
+    return rc;
+}
+
+#endif /* HAVE_HEIF */

--- a/src/ph_heif.h
+++ b/src/ph_heif.h
@@ -1,0 +1,41 @@
+/*
+
+    pHash, the open source perceptual hash library
+    Copyright (C) 2009 Aetilius, Inc.
+
+    HEIF / HEIC / AVIF loader -- thin wrapper around libheif that decodes
+    into a CImg<uint8_t>. Header is always available; the implementation
+    is only compiled / linked when HAVE_HEIF is defined.
+
+*/
+
+#ifndef _PH_HEIF_H
+#define _PH_HEIF_H
+
+#include <stdint.h>
+
+#define cimg_display 0
+#define cimg_debug 0
+#include "CImg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Returns non-zero when the path ends in .heic / .heif / .avif (case
+ * insensitive). Always available -- callers use this to decide whether
+ * to call ph_load_heif. */
+int ph_is_heif_path(const char *file);
+
+#ifdef __cplusplus
+}  // extern "C"
+
+#ifdef HAVE_HEIF
+/* Load a HEIF / HEIC / AVIF file into img. Always produces a 3-channel
+ * RGB CImg<uint8_t>. Returns 0 on success, -1 on any failure. */
+int ph_load_heif(const char *file, cimg_library::CImg<uint8_t> &img);
+#endif
+
+#endif /* __cplusplus */
+
+#endif /* _PH_HEIF_H */


### PR DESCRIPTION
Implements #18: HEIF / HEIC / AVIF image support across every file-taking image hash entry point, gated behind a new `-DWITH_HEIF=ON` CMake option.

## Why

HEIC is the default iPhone photo format and AVIF is now widely deployed on the web and on Android. Both ride on top of the HEIF container, which CImg has no native decoder for, so pHash couldn't ingest either format — `ph_dct_imagehash("photo.heic", …)` would throw `CImgIOException` and abort.

## What

New `src/ph_heif.{cpp,h}`:

- `ph_is_heif_path(file)` — extension probe (`.heic` / `.heif` / `.avif`, case-insensitive). Always available, also exported to the public include.
- `ph_load_heif(file, CImg<uint8_t>&)` — uses libheif to decode to interleaved 24-bit RGB and writes the planar CImg the rest of the library expects. Only present when `HAVE_HEIF` is defined.

`pHash.cpp` gains a small `load_image()` helper that routes HEIF paths to `ph_load_heif()` and falls through to `CImg::load()` for everything else. All four file-loading sites (`ph_dct_imagehash`, `ph_image_digest`, `ph_compare_images`, `ph_mh_imagehash`) now go through it, so **all three image hash families pick up HEIF support transitively** with no API change.

## Graceful degradation

`ph_heif.cpp` is always compiled (it carries the extension probe), but the libheif-using body is gated behind `HAVE_HEIF`. With `-DWITH_HEIF=OFF` (the default) the library builds without libheif and a HEIF input returns `-1` / `NULL` from the image-hash functions instead of crashing. PNG / JPEG / TIFF inputs are unaffected.

## CMake

```cmake
OPTION(WITH_HEIF "HEIF/HEIC/AVIF image support via libheif" OFF)

if(WITH_HEIF)
    find_package(PkgConfig)
    pkg_check_modules(LIBHEIF libheif)
    # ... fallback to find_path/find_library if pkg-config missing ...
    set(HAVE_HEIF 1)
endif()
```

`HAVE_HEIF` is added to `pHash.h.cmake` so it propagates to consumers.

## Verification

Hashing `pHash.png` and the same image re-encoded to HEIC and to AVIF:

```
== DCT image hash ==
  PNG  : 0xfe4ac1a48f94a4cd
  HEIC : 0xfe4ac1a48f94a4cd   Hamming(PNG, HEIC) = 0 / 64
  AVIF : 0xfe4ac1a48f94a4cd   Hamming(PNG, AVIF) = 0 / 64

== Marr-Hildreth hash ==
  PNG vs HEIC normalised distance = 0.0521
  PNG vs AVIF normalised distance = 0.0556

== Radial (Radon) hash via ph_compare_images ==
  PNG vs HEIC pcc = 1.000281
  PNG vs AVIF pcc = 0.997042
```

DCT hashes are bit-identical to the PNG; MH and radial show the small drift expected from lossy HEVC/AV1 re-encoding.

`WITH_HEIF=OFF` was also test-built end-to-end:

```
PNG : rc=0  hash=0xfe4ac1a48f94a4cd     (unchanged)
HEIC: rc=-1 hash=0x0000000000000000     (graceful refusal, not a crash)
```

## Closes

Closes #18.
