### PR TITLE
Fix building with cmake >= 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.14)
 
 include(ExternalProject)
 include(GNUInstallDirs)


### PR DESCRIPTION
cmake_minimum_required version 3.5 is not supported anymore with CMake >= 4.0 which,
CMake < 4.0 is not available anymore in most linux distribution, setting 3.14 is safe and fix the issue 